### PR TITLE
Add 0 DBR borrows

### DIFF
--- a/src/DBR.sol
+++ b/src/DBR.sol
@@ -204,7 +204,7 @@ contract DolaBorrowingRights {
     function onBorrow(address user, uint additionalDebt) public {
         require(markets[msg.sender], "Only markets can call onBorrow");
         accrueDueTokens(user);
-        require(balanceOf(user) >= 0, "DBR Deficit");
+        require(deficitOf(user) == 0, "DBR Deficit");
         debts[user] += additionalDebt;
     }
 


### PR DESCRIPTION
Single line change to allow borrows at 0 DBR. This enables helper contracts to set up positions on behalf of users, without needing DBR flashloans.