### PR TITLE
fix getLiquidatableDebt

### DIFF
--- a/src/Market.sol
+++ b/src/Market.sol
@@ -355,7 +355,7 @@ contract Market {
         uint debt = debts[user];
         if (debt == 0) return 0;
         uint credit = getCreditLimit(user);
-        if(credit > debt) return 0;
+        if(credit >= debt) return 0;
         return debt * liquidationFactorBps / 10000;
     }
 


### PR DESCRIPTION
In the liquidate function, `getCreditLimit(user) < debt` comparison is made to check if user has liquidatable debt. In the getLiquidatableDebt function, the comparison is `if(credit > debt) return 0`. So, it will return a non-zero value when credit == debit while the position will not actually be liquidatable.

Change `if(credit > debt) return 0` to `if(credit >= debt) return 0`.