### PR TITLE
Adjust force replenish collateral requirements

### DIFF
--- a/src/Market.sol
+++ b/src/Market.sol
@@ -563,7 +563,7 @@ contract Market {
         uint replenishmentCost = amount * dbr.replenishmentPriceBps() / 10000;
         uint replenisherReward = replenishmentCost * replenishmentIncentiveBps / 10000;
         debts[user] += replenishmentCost;
-        uint collateralValue = getCollateralValueInternal(user);
+        uint collateralValue = getCollateralValueInternal(user) * (10000 - liquidationIncentiveBps - liquidationFeeBps) / 10000;
         require(collateralValue >= debts[user], "Exceeded collateral value");
         totalDebt += replenishmentCost;
         dbr.onForceReplenish(user, amount);


### PR DESCRIPTION
Reduce the debt limit for which force replenishments are no longer possible. Should save the protocol some potential for bad debt, while also increasing profitability.