### PR TITLE
Add Curvehelper

### DIFF
--- a/src/test/OffchainHelper.t.sol
+++ b/src/test/OffchainHelper.t.sol
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: UNLICENSED 
+pragma solidity ^0.8.13; 
+
+import "../interfaces/IMarket.sol";
+import "forge-std/Test.sol"; 
+import {FrontierV2Test} from "./FrontierV2Test.sol"; 
+import "../BorrowController.sol"; 
+import "../DBR.sol"; 
+import "../Fed.sol"; 
+import {SimpleERC20Escrow} from "../escrows/SimpleERC20Escrow.sol"; 
+import "../Market.sol"; 
+import {CurveHelper} from "../util/CurveHelper.sol";
+import "../Oracle.sol"; 
+ 
+import "./mocks/ERC20.sol"; 
+import "./mocks/BorrowContract.sol"; 
+import {EthFeed} from "./mocks/EthFeed.sol"; 
+
+interface IWeth is IERC20 {
+    function approve(address, uint) external;
+    function withdraw(uint wad) external;
+    function deposit() payable external;
+}
+//This test must be run as a mainnet fork, to work correctly
+contract OffchainHelperTest is FrontierV2Test {
+
+    CurveHelper helper;
+    bytes32 borrowHash;
+    address userPk;
+    uint maxBorrowAmount;
+    IWeth weth;
+
+    function setUp() public {
+        //This will fail if there's no mainnet variable in foundry.toml
+        string memory url = vm.rpcUrl("mainnet");
+        vm.createSelectFork(url);
+
+        initialize(replenishmentPriceBps, collateralFactorBps, replenishmentIncentiveBps, liquidationBonusBps, callOnDepositCallback);
+
+        vm.startPrank(chair);
+        fed.expansion(IMarket(address(market)), 1_000_000e18);
+        vm.stopPrank();
+        
+        dbr = DolaBorrowingRights(0xAD038Eb671c44b853887A7E32528FaB35dC5D710);
+        address pool = 0x056ef502C1Fc5335172bc95EC4cAE16C2eB9b5b6;
+        helper = new CurveHelper(pool); 
+        userPk = vm.addr(1);
+        vm.startPrank(gov);
+        borrowController = BorrowController(0x20C7349f6D6A746a25e66f7c235E96DAC880bc0D);
+        borrowController.allow(address(helper));
+        vm.stopPrank();
+        
+        market = Market(0x63Df5e23Db45a2066508318f172bA45B9CD37035);
+        weth = IWeth(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+        vm.prank(0xF04a5cC80B1E94C69B48f5ee68a08CD2F09A7c3E);
+
+        weth.transfer(userPk, wethTestAmount);
+        maxBorrowAmount = getMaxBorrowAmount(wethTestAmount);
+        vm.startPrank(userPk, userPk);
+        weth.approve(address(helper), type(uint).max);
+        weth.approve(address(market), type(uint).max);
+        DOLA.approve(address(helper), type(uint).max);
+        dbr.approve(address(helper), type(uint).max);
+        vm.stopPrank();
+
+    }
+
+    function testDepositAndBorrowOnBehalf() public {
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+        vm.startPrank(userPk, userPk);
+        helper.depositBuyDbrAndBorrowOnBehalf(IMarket(address(market)), wethTestAmount, borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount, "failed to deposit weth");
+        assertEq(weth.balanceOf(userPk), 0, "failed to deposit weth");
+        assertEq(DOLA.balanceOf(userPk), borrowAmount, "failed to borrow DOLA");
+    }
+
+    function testDepositNativeEthBuyDbrAndBorrowOnBehalf() public {
+        uint duration = 365 days;
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+        uint prevBal = weth.balanceOf(userPk);
+        vm.deal(userPk, wethTestAmount);
+        
+        vm.startPrank(userPk, userPk);
+        helper.depositNativeEthBuyDbrAndBorrowOnBehalf{value:wethTestAmount}(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount, "failed to deposit weth");
+        assertEq(weth.balanceOf(userPk)-prevBal, 0, "failed to deposit weth");
+        assertGt(duration, market.debts(userPk) * 365 days / dbr.balanceOf(userPk) - 1 days); 
+        assertEq(DOLA.balanceOf(userPk), borrowAmount, "failed to borrow DOLA");
+    }
+
+    function testBorrowOnBehalf() public {
+        uint duration = 365 days;
+
+        vm.startPrank(userPk, userPk);
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+        deposit(wethTestAmount);
+        vm.stopPrank();
+        vm.prank(userPk, userPk);
+
+        helper.buyDbrAndBorrowOnBehalf(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount, "failed to deposit weth");
+        assertEq(weth.balanceOf(userPk), 0, "failed to deposit weth");
+        
+        assertGt(duration, market.debts(userPk) * 365 days / dbr.balanceOf(userPk) - 1 days); 
+        assertEq(DOLA.balanceOf(userPk), borrowAmount, "failed to borrow DOLA");
+    }
+
+    function testSellDbrAndRepayOnBehalf() public {
+        vm.startPrank(userPk, userPk);
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+        gibDOLA(userPk, 10000 ether);
+
+        deposit(wethTestAmount);
+
+        helper.buyDbrAndBorrowOnBehalf(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+        helper.sellDbrAndRepayOnBehalf(IMarket(address(market)), market.debts(userPk), dbr.balanceOf(userPk) / 100,dbr.balanceOf(userPk));
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount, "failed to deposit weth");
+        assertEq(weth.balanceOf(userPk), 0, "failed to deposit weth");
+        
+        assertEq(market.debts(userPk), 0, "Did not repay debt"); 
+        assertEq(dbr.balanceOf(userPk), 0, "Did not sell DBR"); 
+    }
+
+    function testSellDbrRepayAndWithdrawOnBehalf() public {
+        gibDOLA(userPk, 10000 ether);
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+        vm.startPrank(userPk, userPk);
+        deposit(wethTestAmount);
+        helper.buyDbrAndBorrowOnBehalf(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+
+        bytes32 withdrawHash = getWithdrawHash(wethTestAmount, 1);
+        (v, r, s) = vm.sign(1, withdrawHash);
+        uint pkBalanceBefore = weth.balanceOf(userPk);
+
+        helper.sellDbrRepayAndWithdrawOnBehalf(
+            IMarket(address(market)),
+            market.debts(userPk),
+            dbr.balanceOf(userPk) / 100,
+            dbr.balanceOf(userPk), 
+            wethTestAmount,
+            block.timestamp,
+            v, r, s);
+        vm.stopPrank();
+        
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), 0, "failed to withdraw weth");
+        assertEq(weth.balanceOf(userPk) - pkBalanceBefore, wethTestAmount, "failed to withdraw weth");
+        assertEq(market.debts(userPk), 0, "Did not repay debt"); 
+        assertEq(dbr.balanceOf(userPk), 0, "Did not sell DBR"); 
+    }
+
+    function testSellDbrRepayAndWithdrawNativeEthOnBehalf() public {
+        gibDOLA(userPk, 10000 ether);
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+        vm.startPrank(userPk, userPk);
+        deposit(wethTestAmount);
+        helper.buyDbrAndBorrowOnBehalf(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+
+        bytes32 withdrawHash = getWithdrawHash(wethTestAmount, 1);
+        (v, r, s) = vm.sign(1, withdrawHash);
+        
+        uint pkBalanceBefore = userPk.balance;
+        helper.sellDbrRepayAndWithdrawNativeEthOnBehalf(
+            IMarket(address(market)),
+            market.debts(userPk),
+            dbr.balanceOf(userPk) / 100,
+            dbr.balanceOf(userPk), 
+            wethTestAmount,
+            block.timestamp,
+            v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), 0, "failed to withdraw weth");
+        assertEq(userPk.balance - pkBalanceBefore, wethTestAmount, "failed to withdraw weth");
+        assertEq(market.debts(userPk), 0, "Did not repay debt"); 
+        assertEq(dbr.balanceOf(userPk), 0, "Did not sell DBR"); 
+    }
+
+    function testWithdrawNativeEthOnBehalf() public {
+        bytes32 withdrawHash = getWithdrawHash(wethTestAmount, 0);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, withdrawHash);
+
+        vm.startPrank(userPk, userPk);
+        deposit(wethTestAmount);
+        uint pkBalanceBefore = userPk.balance;
+        helper.withdrawNativeEthOnBehalf(IMarket(address(market)), wethTestAmount, block.timestamp, v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), 0, "failed to withdraw weth");
+        assertEq(payable(userPk).balance - pkBalanceBefore, wethTestAmount, "failed to withdraw weth");
+    }
+
+    function testDepositNativeEthOnBehalf() public {
+        uint prevBal = weth.balanceOf(address(market.predictEscrow(userPk)));
+        vm.deal(userPk, wethTestAmount);
+
+        vm.startPrank(userPk, userPk);
+        helper.depositNativeEthOnBehalf{value:wethTestAmount}(IMarket(address(market)));
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount+prevBal, "failed to deposit weth");       
+    }
+
+    function testRepayAndWithdrawNativeEthOnBehalf() public {
+        gibDOLA(userPk, 10000 ether);
+        uint borrowAmount = maxBorrowAmount / 2;
+        (uint dolaForDbr, uint dbrNeeded) = helper.approximateDolaAndDbrNeeded(borrowAmount, 365 days, 18);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount + dolaForDbr, 0));
+
+
+        vm.startPrank(userPk, userPk);
+        deposit(wethTestAmount);
+        helper.buyDbrAndBorrowOnBehalf(IMarket(address(market)), borrowAmount, dolaForDbr, dbrNeeded * 99 / 100, block.timestamp, v, r, s);
+
+        bytes32 withdrawHash = getWithdrawHash(wethTestAmount, 1);
+        (v, r, s) = vm.sign(1, withdrawHash);
+
+        uint pkBalanceBefore = userPk.balance;
+        helper.repayAndWithdrawNativeEthOnBehalf(
+            IMarket(address(market)),
+            market.debts(userPk),
+            wethTestAmount,
+            block.timestamp,
+            v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), 0, "failed to withdraw weth");
+        assertEq(userPk.balance - pkBalanceBefore, wethTestAmount, "failed to withdraw weth");
+        assertEq(market.debts(userPk), 0, "Did not repay debt");        
+    }
+
+    function testDepositNativeEthAndBorrowOnBehalf() public {
+        uint borrowAmount = maxBorrowAmount;
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(1, getBorrowHash(borrowAmount, 0));
+
+        vm.startPrank(userPk, userPk);
+        weth.withdraw(wethTestAmount);
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), 0);
+        assertEq(DOLA.balanceOf(userPk), 0);
+        helper.depositNativeEthAndBorrowOnBehalf{value:wethTestAmount}(IMarket(address(market)), borrowAmount, block.timestamp, v, r, s);
+        vm.stopPrank();
+
+        assertEq(weth.balanceOf(address(market.predictEscrow(userPk))), wethTestAmount, "failed to deposit weth");       
+        assertEq(DOLA.balanceOf(userPk), maxBorrowAmount, "failed to borrow");
+        assertEq(market.debts(userPk), DOLA.balanceOf(userPk), "Debt not equal borrow"); 
+    }
+
+    function getWithdrawHash(uint amount, uint nonce) public view returns(bytes32){
+         bytes32 withdrawHash = keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        market.DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                keccak256(
+                                    "WithdrawOnBehalf(address caller,address from,uint256 amount,uint256 nonce,uint256 deadline)"
+                                ),
+                                address(helper),
+                                userPk,
+                                amount,
+                                nonce,
+                                block.timestamp
+                            )
+                        )
+                    )
+                );
+        return withdrawHash;
+    }
+
+    function getBorrowHash(uint amount, uint nonce) public view returns(bytes32){
+        bytes32 hash = keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        market.DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                keccak256(
+                                    "BorrowOnBehalf(address caller,address from,uint256 amount,uint256 nonce,uint256 deadline)"
+                                ),
+                                address(helper),
+                                userPk,
+                                amount,
+                                nonce,
+                                block.timestamp
+                            )
+                        )
+                    )
+                );
+        return hash;
+    }
+}

--- a/src/util/CurveHelper.sol
+++ b/src/util/CurveHelper.sol
@@ -1,0 +1,68 @@
+pragma solidity ^0.8.13;
+import "src/util/OffchainAbstractHelper.sol";
+
+interface ICurvePool {
+    function coins(uint index) external view returns(address);
+    function get_dy(uint i, uint j, uint dx) external view returns(uint);
+    function exchange(uint i, uint j, uint dx, uint min_dy, bool use_eth) external payable returns(uint);
+    function exchange(uint i, uint j, uint dx, uint min_dy, bool use_eth, address receiver) external payable returns(uint);
+}
+
+contract CurveHelper is OffchainAbstractHelper{
+
+    ICurvePool immutable curvePool;
+    uint dbrIndex;
+    uint dolaIndex;
+
+    constructor(address _pool) {
+        curvePool = ICurvePool(_pool);
+        DOLA.approve(_pool, type(uint).max);
+        DBR.approve(_pool, type(uint).max);
+        if(ICurvePool(_pool).coins(0) == address(DOLA)){
+            dolaIndex = 0;
+            dbrIndex = 1;
+        } else {
+            dolaIndex = 1;
+            dbrIndex = 0;
+        }
+    }
+
+    /**
+    @notice Sells an exact amount of DBR for DOLA in a curve pool
+    @param amount Amount of DBR to sell
+    @param minOut minimum amount of DOLA to receive
+    */
+    function _sellDbr(uint amount, uint minOut) internal override {
+        curvePool.exchange(dbrIndex, dolaIndex, amount, minOut, false);
+    }
+
+    /**
+    @notice Buys an exact amount of DBR for DOLA in a curve pool
+    @param amount Amount of DOLA to sell
+    @param minOut minimum amount of DBR out
+    */
+    function _buyDbr(uint amount, uint minOut, address receiver) internal override {
+        curvePool.exchange(dolaIndex, dbrIndex, amount, minOut, false, receiver);
+    }
+    
+    /**
+    @notice Approximates the total amount of dola and dbr needed to borrow a dolaBorrowAmount while also borrowing enought to buy the DBR needed to cover for the borrowing period
+    @dev Uses a binary search to approximate the amounts needed.
+    @param dolaBorrowAmount Amount of dola the user wishes to end up with
+    @param period Amount of time in seconds the loan will last
+    @param iterations Number of approximation iterations. The higher the more precise the result
+    */
+    function approximateDolaAndDbrNeeded(uint dolaBorrowAmount, uint period, uint iterations) public view override returns(uint dolaForDbr, uint dbrNeeded){
+        uint amountIn = dolaBorrowAmount;
+        for(uint i; i < iterations; ++i){
+            uint dbrToBuy = (amountIn + dolaBorrowAmount) * period / 365 days;
+            uint dbrReceived = curvePool.get_dy(dolaIndex, dbrIndex, amountIn);
+            if(dbrReceived > dbrToBuy){
+                amountIn = amountIn / 2;
+            } else {
+                amountIn = amountIn + amountIn/2;
+            }
+        }
+        return (amountIn, (dolaBorrowAmount + amountIn) * period / 365 days);
+    }
+}

--- a/src/util/CurveHelper.sol
+++ b/src/util/CurveHelper.sol
@@ -10,7 +10,7 @@ interface ICurvePool {
 
 contract CurveHelper is OffchainAbstractHelper{
 
-    ICurvePool immutable curvePool;
+    ICurvePool public immutable curvePool;
     uint dbrIndex;
     uint dolaIndex;
 
@@ -33,7 +33,9 @@ contract CurveHelper is OffchainAbstractHelper{
     @param minOut minimum amount of DOLA to receive
     */
     function _sellDbr(uint amount, uint minOut) internal override {
-        curvePool.exchange(dbrIndex, dolaIndex, amount, minOut, false);
+        if(amount > 0){
+            curvePool.exchange(dbrIndex, dolaIndex, amount, minOut, false);
+        }
     }
 
     /**
@@ -42,12 +44,14 @@ contract CurveHelper is OffchainAbstractHelper{
     @param minOut minimum amount of DBR out
     */
     function _buyDbr(uint amount, uint minOut, address receiver) internal override {
-        curvePool.exchange(dolaIndex, dbrIndex, amount, minOut, false, receiver);
+        if(amount > 0) {
+            curvePool.exchange(dolaIndex, dbrIndex, amount, minOut, false, receiver);
+        }
     }
     
     /**
-    @notice Approximates the total amount of dola and dbr needed to borrow a dolaBorrowAmount while also borrowing enought to buy the DBR needed to cover for the borrowing period
-    @dev Uses a binary search to approximate the amounts needed.
+    @notice Approximates the total amount of dola and dbr needed to borrow a dolaBorrowAmount while also borrowing enough to buy the DBR needed to cover for the borrowing period
+    @dev Uses a binary search to approximate the amounts needed. Should only be called as part of generating transaction parameters.
     @param dolaBorrowAmount Amount of dola the user wishes to end up with
     @param period Amount of time in seconds the loan will last
     @param iterations Number of approximation iterations. The higher the more precise the result

--- a/src/util/CurveHelper.sol
+++ b/src/util/CurveHelper.sol
@@ -54,14 +54,16 @@ contract CurveHelper is OffchainAbstractHelper{
     */
     function approximateDolaAndDbrNeeded(uint dolaBorrowAmount, uint period, uint iterations) public view override returns(uint dolaForDbr, uint dbrNeeded){
         uint amountIn = dolaBorrowAmount;
+        uint stepSize = amountIn / 2;
         for(uint i; i < iterations; ++i){
             uint dbrToBuy = (amountIn + dolaBorrowAmount) * period / 365 days;
             uint dbrReceived = curvePool.get_dy(dolaIndex, dbrIndex, amountIn);
             if(dbrReceived > dbrToBuy){
-                amountIn = amountIn / 2;
+                amountIn -= stepSize;
             } else {
-                amountIn = amountIn + amountIn/2;
+                amountIn += stepSize;
             }
+            stepSize /= 2;
         }
         return (amountIn, (dolaBorrowAmount + amountIn) * period / 365 days);
     }

--- a/src/util/OffchainAbstractHelper.sol
+++ b/src/util/OffchainAbstractHelper.sol
@@ -1,0 +1,361 @@
+pragma solidity ^0.8.13;
+import "../interfaces/IMarket.sol";
+interface IERC20 {
+    function transfer(address to, uint amount) external;
+    function transferFrom(address from, address to, uint amount) external;
+    function approve(address to, uint amount) external;
+    function balanceOf(address user) external view returns(uint);
+}
+
+interface IWETH is IERC20 {
+    function withdraw(uint wad) external;
+    function deposit() external payable;
+}
+
+abstract contract OffchainAbstractHelper {
+
+    IERC20 constant DOLA = IERC20(0x865377367054516e17014CcdED1e7d814EDC9ce4);
+    IERC20 constant DBR = IERC20(0xAD038Eb671c44b853887A7E32528FaB35dC5D710);
+    IWETH constant WETH = IWETH(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+    
+    /**
+    Virtual functions implemented by the AMM interfacing part of the Helper contract
+    */
+
+    /**
+    @notice Buys DBR for an amount of Dola
+    @param amount Amount of Dola to spend on DBR
+    @param minOut minimum amount of DBR to receive
+    */
+    function _buyDbr(uint amount, uint minOut, address receiver) internal virtual;
+
+    /**
+    @notice Sells an exact amount of DBR for DOLA
+    @param amount Amount of DBR to sell
+    @param minOut minimum amount of DOLA to receive
+    */
+    function _sellDbr(uint amount, uint minOut) internal virtual;
+
+    /**
+    @notice Approximates the amount of additional DOLA and DBR needed to sustain dolaBorrowAmount over the period
+    @dev Larger number of iterations increases both accuracy of the approximation and gas cost. This method should not be called in smart contract code.
+    @param dolaBorrowAmount The amount of DOLA the user wishes to borrow before covering DBR expenses
+    @param minDbr The amount of seconds the user wish to borrow the DOLA for
+    @param iterations The amount of approximation iterations.
+    @return Tuple of (dolaNeeded, dbrNeeded) representing the total dola needed to pay for the DBR and pay out dolaBorrowAmount and the dbrNeeded to sustain the loan over the period
+    */
+    function approximateDolaAndDbrNeeded(uint dolaBorrowAmount, uint minDbr, uint iterations) public view virtual returns(uint, uint);
+
+    /**
+    @notice Borrows on behalf of the caller, buying the necessary DBR to pay for the loan over the period, by borrowing aditional funds to pay for the necessary DBR
+    @dev Has to borrow the dolaForDbr amount due to how the market's borrowOnBehalf functions, and repay the excess at the end of the call resulting in a weird repay event
+    @param market Market the caller wishes to borrow from
+    @param dolaAmount Amount the caller wants to end up with at their disposal
+    @param dolaForDbr The max amount of debt the caller is willing to end up with
+     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
+    @param minDbr The minDbr the caller wish to borrow for
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function buyDbrAndBorrowOnBehalf(
+        IMarket market, 
+        uint dolaAmount,
+        uint dolaForDbr,
+        uint minDbr,
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        public 
+    {
+        //Borrow Dola
+        uint totalBorrow = dolaAmount + dolaForDbr;
+        market.borrowOnBehalf(msg.sender, totalBorrow, deadline, v, r, s);
+        
+        //Buy DBR
+        _buyDbr(dolaForDbr, minDbr, msg.sender);
+
+        //Transfer remaining DOLA amount to user
+        DOLA.transfer(msg.sender, dolaAmount);
+    }
+
+    /**
+    @notice Deposits collateral and borrows on behalf of the caller, buying the necessary DBR to pay for the loan over the period, by borrowing aditional funds to pay for the necessary DBR
+    @dev Has to borrow the dolaForDbr amount due to how the market's borrowOnBehalf functions, and repay the excess at the end of the call resulting in a weird repay event
+    @param market Market the caller wish to deposit to and borrow from
+    @param dolaAmount Amount the caller wants to end up with at their disposal
+    @param dolaForDbr The max amount of debt the caller is willing to take on to buy dbr
+     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
+    @param minDbr The minDbr the caller wish to borrow for
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function depositBuyDbrAndBorrowOnBehalf(
+        IMarket market, 
+        uint collateralAmount, 
+        uint dolaAmount,
+        uint dolaForDbr,
+        uint minDbr,
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        public 
+    {
+        IERC20 collateral = IERC20(market.collateral());
+
+        //Deposit collateral
+        collateral.transferFrom(msg.sender, address(this), collateralAmount);
+        collateral.approve(address(market), collateralAmount);
+        market.deposit(msg.sender, collateralAmount);
+
+        //Borrow dola and buy dbr
+        buyDbrAndBorrowOnBehalf(market, dolaAmount, dolaForDbr, minDbr, deadline, v, r , s);
+    }
+
+    /**
+    @notice Deposits native eth as collateral and borrows on behalf of the caller,
+    buying the necessary DBR to pay for the loan over the period, by borrowing aditional funds to pay for the necessary DBR
+    @dev Has to borrow the dolaForDbr amount due to how the market's borrowOnBehalf functions, and repay the excess at the end of the call resulting in a weird repay event
+    @param market Market the caller wish to deposit to and borrow from
+    @param dolaAmount Amount the caller wants to end up with at their disposal
+    @param dolaForDbr The max amount of debt the caller is willing to end up with
+     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
+    @param minDbr The minDbr the caller wish to borrow for
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function depositNativeEthBuyDbrAndBorrowOnBehalf(
+        IMarket market, 
+        uint dolaAmount,
+        uint dolaForDbr,
+        uint minDbr,
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        public payable
+    {
+        IERC20 collateral = IERC20(market.collateral());
+        require(address(collateral) == address(WETH), "Market is not an ETH market");
+        WETH.deposit{value:msg.value}();
+
+        //Deposit collateral
+        collateral.approve(address(market), msg.value);
+        market.deposit(msg.sender, msg.value);
+
+        //Borrow dola and buy dbr
+        buyDbrAndBorrowOnBehalf(market, dolaAmount, dolaForDbr, minDbr, deadline, v, r , s);
+    }
+
+    /**
+    @notice Sells DBR on behalf of the caller and uses the proceeds along with DOLA from the caller to repay debt.
+    @dev The caller is unlikely to spend all of the DOLA they make available for the function call
+    @param market The market the user wishes to repay debt in
+    @param dolaAmount The maximum amount of dola debt the user is willing to repay
+    @param minDolaFromDbr The minimum amount of DOLA the caller expects to get in return for selling their DBR.
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+    @param dbrAmountToSell The amount of DBR the caller wishes to sell
+    */
+    function sellDbrAndRepayOnBehalf(IMarket market, uint dolaAmount, uint minDolaFromDbr, uint dbrAmountToSell) public {
+        uint dbrBal = DBR.balanceOf(msg.sender);
+
+        //If user has less DBR than ordered, sell what's available
+        if(dbrAmountToSell > dbrBal){
+            DBR.transferFrom(msg.sender, address(this), dbrBal);
+            _sellDbr(dbrBal, minDolaFromDbr);
+        } else {
+            DBR.transferFrom(msg.sender, address(this), dbrAmountToSell);
+            _sellDbr(dbrAmountToSell, minDolaFromDbr);
+        }
+
+        uint debt = market.debts(msg.sender);
+        uint dolaBal = DOLA.balanceOf(address(this));
+        
+        //If the debt is lower than the dolaAmount, repay debt else repay dolaAmount
+        uint repayAmount = debt < dolaAmount ? debt : dolaAmount;
+
+        //If dolaBal is less than repayAmount, transfer remaining DOLA from user, otherwise transfer excess dola to user
+        if(dolaBal < repayAmount){
+            DOLA.transferFrom(msg.sender, address(this), repayAmount - dolaBal);
+        } else {
+            DOLA.transfer(msg.sender, dolaBal - repayAmount);
+        }
+
+        //Repay repayAmount
+        DOLA.approve(address(market), repayAmount);
+        market.repay(msg.sender, repayAmount);
+    }
+
+    /**
+    @notice Sells DBR on behalf of the caller and uses the proceeds along with DOLA from the caller to repay debt, and then withdraws collateral
+    @dev The caller is unlikely to spend all of the DOLA they make available for the function call
+    @param market Market the user wishes to repay debt in
+    @param dolaAmount Maximum amount of dola debt the user is willing to repay
+    @param minDolaFromDbr Minimum amount of DOLA the caller expects to get in return for selling their DBR
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+    @param dbrAmountToSell Amount of DBR the caller wishes to sell
+    @param collateralAmount Amount of collateral to withdraw
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function sellDbrRepayAndWithdrawOnBehalf(
+        IMarket market, 
+        uint dolaAmount, 
+        uint minDolaFromDbr,
+        uint dbrAmountToSell, 
+        uint collateralAmount, 
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        external 
+    {
+        //Repay
+        sellDbrAndRepayOnBehalf(market, dolaAmount, minDolaFromDbr, dbrAmountToSell);
+
+        //Withdraw
+        market.withdrawOnBehalf(msg.sender, collateralAmount, deadline, v, r, s);
+
+        //Transfer collateral to msg.sender
+        IERC20(market.collateral()).transfer(msg.sender, collateralAmount);
+    }
+
+    /**
+    @notice Sells DBR on behalf of the caller and uses the proceeds along with DOLA from the caller to repay debt, and then withdraws collateral
+    @dev The caller is unlikely to spend all of the DOLA they make available for the function call
+    @param market Market the user wishes to repay debt in
+    @param dolaAmount Maximum amount of dola debt the user is willing to repay
+    @param minDolaFromDbr Minimum amount of DOLA the caller expects to get in return for selling their DBR
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+    @param dbrAmountToSell Amount of DBR the caller wishes to sell
+    @param collateralAmount Amount of collateral to withdraw
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function sellDbrRepayAndWithdrawNativeEthOnBehalf(
+        IMarket market, 
+        uint dolaAmount, 
+        uint minDolaFromDbr,
+        uint dbrAmountToSell, 
+        uint collateralAmount, 
+        uint deadline, 
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        external 
+    {
+        //Repay
+        sellDbrAndRepayOnBehalf(market, dolaAmount, minDolaFromDbr, dbrAmountToSell);
+
+        //Withdraw
+        withdrawNativeEthOnBehalf(market, collateralAmount, deadline, v, r, s);
+    }
+
+    /**
+    @notice Repays debt, and then withdraws native ETH
+    @dev The caller is unlikely to spend all of the DOLA they make available for the function call
+    @param market Market the user wishes to repay debt in
+    @param dolaAmount Amount of dola debt the user is willing to repay    
+    @param collateralAmount Amount of collateral to withdraw
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function repayAndWithdrawNativeEthOnBehalf(
+        IMarket market, 
+        uint dolaAmount,                 
+        uint collateralAmount, 
+        uint deadline,
+        uint8 v, 
+        bytes32 r, 
+        bytes32 s) 
+        external 
+    {        
+        // Repay
+        DOLA.transferFrom(msg.sender, address(this), dolaAmount);        
+        DOLA.approve(address(market), dolaAmount);
+        market.repay(msg.sender, dolaAmount);
+
+        // Withdraw
+        withdrawNativeEthOnBehalf(market, collateralAmount, deadline, v, r, s);
+    }
+
+    /**
+    @notice Helper function for depositing native eth to WETH markets
+    @param market The WETH market to deposit to
+    */
+    function depositNativeEthOnBehalf(IMarket market) public payable {
+        require(address(market.collateral()) == address(WETH), "Not an ETH market");
+        WETH.deposit{value:msg.value}();
+        WETH.approve(address(market), msg.value);
+        market.deposit(msg.sender, msg.value);
+    }
+
+    /**
+    @notice Helper function for depositing native eth to WETH markets before borrowing on behalf of the depositor
+    @param market The WETH market to deposit to
+    @param borrowAmount The amount to borrow on behalf of the depositor
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function depositNativeEthAndBorrowOnBehalf(IMarket market, uint borrowAmount, uint deadline, uint8 v, bytes32 r, bytes32 s) public payable {
+        require(address(market.collateral()) == address(WETH), "Not an ETH market");
+
+        //Deposit native eth
+        WETH.deposit{value:msg.value}();
+        WETH.approve(address(market), msg.value);
+        market.deposit(msg.sender, msg.value);
+
+        //Borrow Dola
+        market.borrowOnBehalf(msg.sender, borrowAmount, deadline, v, r, s);
+        DOLA.transfer(msg.sender, borrowAmount);
+    }
+
+    /**
+    @notice Helper function for withdrawing to native eth
+    @param market WETH market to withdraw collateral from
+    @param collateralAmount Amount of collateral to withdraw
+    @param deadline Deadline of the signature
+    @param v V parameter of the signature
+    @param r R parameter of the signature
+    @param s S parameter of the signature
+    */
+    function withdrawNativeEthOnBehalf(
+        IMarket market,
+        uint collateralAmount,
+        uint deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s)
+        public
+    {
+        market.withdrawOnBehalf(msg.sender, collateralAmount, deadline, v, r, s);
+
+        IERC20 collateral = IERC20(market.collateral());
+        require(address(collateral) == address(WETH), "Not an ETH market");
+        WETH.withdraw(collateralAmount);
+
+        (bool success,) = payable(msg.sender).call{value:collateralAmount}("");
+        require(success, "Failed to transfer ETH");
+    }
+    
+    //Empty receive function for receiving the native eth sent by the WETH contract
+    receive() external payable {}
+}


### PR DESCRIPTION
Add abstract Curvehelper contract

The Curve helper contract needed some rearchitecturing of the helper contract architecture, as it's non-trivial to buy a specific amount of a token X for some amount of token Y in.

The biggest change beyond targeting curve, is moving from an approximation of additional DOLA and DBR needed which is calculated on-chain, to one that is calculated off-chain.