### PR TITLE
Bug/dbr distributor too loose market restrictions

### DIFF
--- a/src/DbrDistributor.sol
+++ b/src/DbrDistributor.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
+import "src/interfaces/IERC20.sol";
 
 interface IDBR {
     function markets(address) external view returns (bool);
@@ -13,6 +14,7 @@ interface IINVEscrow {
 
 interface IMarket {
     function escrows(address) external view returns (address);
+    function collateral() external view returns (IERC20);
 }
 
 contract DbrDistributor {
@@ -20,6 +22,7 @@ contract DbrDistributor {
     IDBR public immutable dbr;
     address public gov;
     address public operator;
+    address public constant INV = 0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68;
     uint public constant mantissa = 10**18;
     uint public minRewardRate; // starts at 0
     uint public maxRewardRate = type(uint).max / 3652500 days; // 10,000 years
@@ -65,6 +68,7 @@ contract DbrDistributor {
         IMarket market = IMarket(IINVEscrow(msg.sender).market());
         address beneficiary = IINVEscrow(msg.sender).beneficiary();
         require(dbr.markets(address(market)), "UNSUPPORTED MARKET");
+        require(address(market.collateral()) == address(INV), "UNSUPPORTED TOKEN");
         require(market.escrows(beneficiary) == msg.sender, "MSG SENDER NOT A VALID ESCROW");
     }
 

--- a/src/escrows/INVEscrow.sol
+++ b/src/escrows/INVEscrow.sol
@@ -1,16 +1,8 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
+import "../interfaces/IERC20.sol";
 
 // @dev Caution: We assume all failed transfers cause reverts and ignore the returned bool.
-interface IERC20 {
-    function transfer(address,uint) external returns (bool);
-    function transferFrom(address,address,uint) external returns (bool);
-    function balanceOf(address) external view returns (uint);
-    function approve(address, uint) external returns (bool);
-    function delegate(address delegatee) external;
-    function delegates(address delegator) external view returns (address delegatee);
-}
-
 interface IXINV {
     function balanceOf(address) external view returns (uint);
     function exchangeRateStored() external view returns (uint);
@@ -34,7 +26,7 @@ interface IDbrDistributor {
 */
 contract INVEscrow {
     address public market;
-    IERC20 public token;
+    IDelegateableERC20 public token;
     address public beneficiary;
     IXINV public immutable xINV;
     IDbrDistributor public immutable distributor;
@@ -51,7 +43,7 @@ contract INVEscrow {
     @param _token The IERC20 token representing the INV governance token
     @param _beneficiary The beneficiary who may delegate token voting power
     */
-    function initialize(IERC20 _token, address _beneficiary) public {
+    function initialize(IDelegateableERC20 _token, address _beneficiary) public {
         require(market == address(0), "ALREADY INITIALIZED");
         market = msg.sender;
         token = _token;

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -7,3 +7,8 @@ interface IERC20 {
     function balanceOf(address) external view returns (uint);
 }
 
+interface IDelegateableERC20 is IERC20 {
+    function delegate(address delegatee) external;
+    function delegates(address delegator) external view returns (address delegatee);
+}
+

--- a/src/test/escrowForkTests/INVEscrowFork.t.sol
+++ b/src/test/escrowForkTests/INVEscrowFork.t.sol
@@ -2,12 +2,14 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Test.sol";
-import "../../escrows/INVEscrow.sol";
+import "../../interfaces/IERC20.sol";
+import {INVEscrow, IXINV, IDbrDistributor} from "../../escrows/INVEscrow.sol";
 import "../../DBR.sol";
-import "../../DbrDistributor.sol";
+import {DbrDistributor, IMarket, IDBR} from "../../DbrDistributor.sol";
 
 contract MockMarket is IMarket {
     mapping(address => address) public escrows;
+    IERC20 public collateral = IERC20(0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68);
     function addEscrow(address owner, address escrow) external {
         escrows[owner] = escrow;
     }
@@ -19,7 +21,7 @@ contract INVEscrowForkTest is Test{
     address claimant = address(0xC);
     address holder = address(0x926dF14a23BE491164dCF93f4c468A50ef659D5B);
     address gov = address(0x926dF14a23BE491164dCF93f4c468A50ef659D5B);
-    IERC20 INV = IERC20(0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68);
+    IDelegateableERC20 INV = IDelegateableERC20(0x41D5D79431A913C4aE7d69a668ecdfE5fF9DFB68);
     IXINV xINV = IXINV(0x1637e4e9941D55703a7A5E7807d6aDA3f7DCD61B);
     DolaBorrowingRights DBR = DolaBorrowingRights(0xAD038Eb671c44b853887A7E32528FaB35dC5D710);
     DbrDistributor distributor;


### PR DESCRIPTION
Address point 5. in Nomoi audit report:
_"The DbrDistributor.onlyINVEscrow modifier is intended to grant access exclusively to
escrows of specific markets, such as the INVEscrow . In order to achieve this, it checks
if the msg.sender is a valid escrow by verifying that the associated market is registered
in the DBR contract.
However, the current implementation fails to effectively limit access to specific markets,
and could result in escrows from unintended markets calling these functions. The impact
of this will completely depend on the escrow's implementation."_

While the implemented fix differs from the suggested one by the Nomoi team, it achieves the desired result of prohibiting all interactions to the DbrDistributor contract to:
1. Escrows which markets are live in the FiRM system by being recognized by the DBR contract.
2. Markets which use the INV token as collateral.