### PR TITLE
Improvement/add max withdraw

### DIFF
--- a/src/Market.sol
+++ b/src/Market.sol
@@ -488,6 +488,15 @@ contract Market {
     }
 
     /**
+    @notice Function for withdrawing maximum allowed to msg.sender.
+    @dev Useful for use with escrows that continously compound tokens, so there won't be dust amounts left
+    @dev Dangerous to use when the user has any amount of debt!
+    */
+    function withdrawMax() public {
+        withdrawInternal(msg.sender, msg.sender, getWithdrawalLimitInternal(msg.sender));
+    }
+
+    /**
     @notice Function for using a signed message to withdraw on behalf of an address owning an escrow with collateral.
     @dev Signed messaged can be invalidated by incrementing the nonce. Will always withdraw to the msg.sender.
     @param from The address of the user owning the escrow being withdrawn from
@@ -525,6 +534,47 @@ contract Market {
             );
             require(recoveredAddress != address(0) && recoveredAddress == from, "INVALID_SIGNER");
             withdrawInternal(from, msg.sender, amount);
+        }
+    }
+
+    /**
+    @notice Function for using a signed message to withdraw on behalf of an address owning an escrow with collateral.
+    @dev Signed messaged can be invalidated by incrementing the nonce. Will always withdraw to the msg.sender.
+    @dev Useful for use with escrows that continously compound tokens, so there won't be dust amounts left
+    @dev Dangerous to use when the user has any amount of debt!
+    @param from The address of the user owning the escrow being withdrawn from
+    @param deadline Timestamp after which the signed message will be invalid
+    @param v The v param of the ECDSA signature
+    @param r The r param of the ECDSA signature
+    @param s The s param of the ECDSA signature
+    */
+    function withdrawMaxOnBehalf(address from, uint deadline, uint8 v, bytes32 r, bytes32 s) public {
+        require(deadline >= block.timestamp, "DEADLINE_EXPIRED");
+        unchecked {
+            address recoveredAddress = ecrecover(
+                keccak256(
+                    abi.encodePacked(
+                        "\x19\x01",
+                        DOMAIN_SEPARATOR(),
+                        keccak256(
+                            abi.encode(
+                                keccak256(
+                                    "WithdrawOnBehalf(address caller,address from,uint256 nonce,uint256 deadline)"
+                                ),
+                                msg.sender,
+                                from,
+                                nonces[from]++,
+                                deadline
+                            )
+                        )
+                    )
+                ),
+                v,
+                r,
+                s
+            );
+            require(recoveredAddress != address(0) && recoveredAddress == from, "INVALID_SIGNER");
+            withdrawInternal(from, msg.sender, getWithdrawalLimitInternal(from));
         }
     }
 


### PR DESCRIPTION
Add `withdrawMax()` and `withdrawMaxOnBehalf(...)` functions to the Market contract. These functions are necessary to allow users to deploy everything from their self-accruing personal escrows like that for xINV, and has so far been unnecessary.

The addition has the slight benefit of being slightly cheaper to execute on rollups, as the calls use less calldata than a standard withdraw.