### PR TITLE
Feat: wBTC market

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,8 @@
 src = 'src'
 out = 'out'
 libs = ['lib']
-solc = "0.8.13"
+solc = "0.8.20"
+evm_version = "shanghai"
 [rpc_endpoints]
 mainnet = "${RPC_MAINNET}"
 

--- a/src/feeds/WbtcPriceFeed.sol
+++ b/src/feeds/WbtcPriceFeed.sol
@@ -38,7 +38,7 @@ contract WbtcPriceFeed {
         (uint80 btcUsdRoundId,int256 btcUsdPrice,uint btcUsdStartedAt,uint btcUsdUpdatedAt,uint80 btcUsdAnsweredInRound) = btcToUsd.latestRoundData();
         int wbtcUsdPrice = btcUsdPrice * 10**8 / wbtcBtcPrice;
         if(isPriceOutOfBounds(wbtcBtcPrice, wbtcToBtc)){
-            wbtcUsdPrice = wbtcToUsdFallback();
+            wbtcUsdPrice = wbtcToUsdFallbackOracle();
         }
         if(wbtcBtcUpdatedAt < btcUsdUpdatedAt){
             return (wbtcBtcRoundId, wbtcUsdPrice, wbtcBtcStartedAt, wbtcBtcUpdatedAt, wbtcBtcAnsweredInRound);
@@ -65,7 +65,7 @@ contract WbtcPriceFeed {
      * @dev The function assumes that the `price_oracle` returns the price with 18 decimals, and it adjusts to 8 decimals for compatibility with Chainlink oracles.
      * @return int Returns the WBTC price in USD format with reduced decimals.
      */
-    function wbtcToUsdFallback() public view returns (int){
+    function wbtcToUsdFallbackOracle() public view returns (int){
         //0 index is wbtc usdt price
         //Reduce to 8 decimals to be in line with chainlink oracles
         return int(tricrypto.price_oracle(0) / 10**10);

--- a/src/feeds/WbtcPriceFeed.sol
+++ b/src/feeds/WbtcPriceFeed.sol
@@ -1,14 +1,24 @@
-pragma solidity ^0.8.13;
+pragma solidity ^0.8.20;
 
 interface IChainlinkFeed {
+    function aggregator() external view returns(address aggregator);
     function decimals() external view returns (uint8 decimals);
     function latestRoundData() external view returns (uint80 roundId, int256 crvUsdPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
 }
+interface IAggregator {
+    function maxAnswer() external view returns(int192);
+    function minAnswer() external view returns(int192);
+}
+interface ICurvePool {
+    function price_oracle(uint k) external view returns (uint256);
+}
 
-contract WbtcPriceFeed is IChainlinkFeed {
+
+contract WbtcPriceFeed {
     
     IChainlinkFeed public btcToUsd = IChainlinkFeed(0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c);
     IChainlinkFeed public wbtcToBtc = IChainlinkFeed(0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23);
+    ICurvePool public tricrypto = ICurvePool(0xf5f5B97624542D72A9E06f04804Bf81baA15e2B4);
 
     function decimals() external view returns (uint8){
         return 8;
@@ -27,10 +37,37 @@ contract WbtcPriceFeed is IChainlinkFeed {
         (uint80 wbtcBtcRoundId,int256 wbtcBtcPrice,uint wbtcBtcStartedAt,uint wbtcBtcUpdatedAt,uint80 wbtcBtcAnsweredInRound) = wbtcToBtc.latestRoundData();
         (uint80 btcUsdRoundId,int256 btcUsdPrice,uint btcUsdStartedAt,uint btcUsdUpdatedAt,uint80 btcUsdAnsweredInRound) = btcToUsd.latestRoundData();
         int wbtcUsdPrice = btcUsdPrice * 10**8 / wbtcBtcPrice;
+        if(isPriceOutOfBounds(wbtcBtcPrice, wbtcToBtc)){
+            wbtcUsdPrice = wbtcToUsdFallback();
+        }
         if(wbtcBtcUpdatedAt < btcUsdUpdatedAt){
             return (wbtcBtcRoundId, wbtcUsdPrice, wbtcBtcStartedAt, wbtcBtcUpdatedAt, wbtcBtcAnsweredInRound);
         } else {
             return (btcUsdRoundId, wbtcUsdPrice, btcUsdStartedAt, btcUsdUpdatedAt, btcUsdAnsweredInRound);
         }
+    }
+
+    /**
+     * @notice Checks if a given price is out of the boundaries defined in the Chainlink aggregator.
+     * @param price The price to be checked.
+     * @param feed The Chainlink feed to retrieve the boundary information from.
+     * @return bool Returns `true` if the price is out of bounds, otherwise `false`.
+     */
+    function isPriceOutOfBounds(int price, IChainlinkFeed feed) public view returns(bool){
+        IAggregator aggregator = IAggregator(feed.aggregator());
+        int192 max = aggregator.maxAnswer();
+        int192 min = aggregator.minAnswer();
+        return(max <= price || min >= price);
+    }
+
+    /**
+     * @notice Fetches the WBTC to USDT price and adjusts the decimals to match Chainlink oracles.
+     * @dev The function assumes that the `price_oracle` returns the price with 18 decimals, and it adjusts to 8 decimals for compatibility with Chainlink oracles.
+     * @return int Returns the WBTC price in USD format with reduced decimals.
+     */
+    function wbtcToUsdFallback() public view returns (int){
+        //0 index is wbtc usdt price
+        //Reduce to 8 decimals to be in line with chainlink oracles
+        return int(tricrypto.price_oracle(0) / 10**10);
     }
 }

--- a/src/feeds/WbtcPriceFeed.sol
+++ b/src/feeds/WbtcPriceFeed.sol
@@ -1,0 +1,36 @@
+pragma solidity ^0.8.13;
+
+interface IChainlinkFeed {
+    function decimals() external view returns (uint8 decimals);
+    function latestRoundData() external view returns (uint80 roundId, int256 crvUsdPrice, uint256 startedAt, uint256 updatedAt, uint80 answeredInRound);
+}
+
+contract WbtcPriceFeed is IChainlinkFeed {
+    
+    IChainlinkFeed public btcToUsd = IChainlinkFeed(0xF4030086522a5bEEa4988F8cA5B36dbC97BeE88c);
+    IChainlinkFeed public wbtcToBtc = IChainlinkFeed(0xfdFD9C85aD200c506Cf9e21F1FD8dd01932FBB23);
+
+    function decimals() external view returns (uint8){
+        return 8;
+    }
+
+    /**
+     * @notice Retrieves the latest round data for the wBTC token price feed
+     * @dev This function calculates the wBTC price in USD by combining the BTC to USD price from a Chainlink oracle and the wBTC to BTC ratio from another Chainlink oracle
+     * @return roundId The round ID of the Chainlink price feed for the feed with the lowest updatedAt feed
+     * @return wbtcUsdPrice The latest wBTC price in USD computed from the Wbtc/BTC and BTC/USD feeds
+     * @return startedAt The timestamp when the latest round of Chainlink price feed started of the lowest last updatedAt feed
+     * @return updatedAt The lowest timestamp when either of the latest round of Chainlink price feed was updated
+     * @return answeredInRound The round ID in which the answer was computed of the lowest updatedAt feed
+     */
+    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80){
+        (uint80 wbtcBtcRoundId,int256 wbtcBtcPrice,uint wbtcBtcStartedAt,uint wbtcBtcUpdatedAt,uint80 wbtcBtcAnsweredInRound) = wbtcToBtc.latestRoundData();
+        (uint80 btcUsdRoundId,int256 btcUsdPrice,uint btcUsdStartedAt,uint btcUsdUpdatedAt,uint80 btcUsdAnsweredInRound) = btcToUsd.latestRoundData();
+        int wbtcUsdPrice = btcUsdPrice * 10**8 / wbtcBtcPrice;
+        if(wbtcBtcUpdatedAt < btcUsdUpdatedAt){
+            return (wbtcBtcRoundId, wbtcUsdPrice, wbtcBtcStartedAt, wbtcBtcUpdatedAt, wbtcBtcAnsweredInRound);
+        } else {
+            return (btcUsdRoundId, wbtcUsdPrice, btcUsdStartedAt, btcUsdUpdatedAt, btcUsdAnsweredInRound);
+        }
+    }
+}

--- a/src/feeds/WbtcPriceFeed.sol
+++ b/src/feeds/WbtcPriceFeed.sol
@@ -36,7 +36,7 @@ contract WbtcPriceFeed {
      * @return updatedAt The lowest timestamp when either of the latest round of Chainlink price feed was updated
      * @return answeredInRound The round ID in which the answer was computed of the lowest updatedAt feed
      */
-    function latestRoundData() external view returns (uint80, int256, uint256, uint256, uint80){
+    function latestRoundData() public view returns (uint80, int256, uint256, uint256, uint80){
         (uint80 wbtcBtcRoundId,int256 wbtcBtcPrice,uint wbtcBtcStartedAt,uint wbtcBtcUpdatedAt,uint80 wbtcBtcAnsweredInRound) = wbtcToBtc.latestRoundData();
         (uint80 btcUsdRoundId,int256 btcUsdPrice,uint btcUsdStartedAt,uint btcUsdUpdatedAt,uint80 btcUsdAnsweredInRound) = btcToUsd.latestRoundData();
         int wbtcUsdPrice = btcUsdPrice * 10**8 / wbtcBtcPrice;
@@ -48,6 +48,15 @@ contract WbtcPriceFeed {
         } else {
             return (btcUsdRoundId, wbtcUsdPrice, btcUsdStartedAt, btcUsdUpdatedAt, btcUsdAnsweredInRound);
         }
+    }
+    /**
+     * @notice Returns the latest price only
+     * @dev Unlike chainlink oracles, the latestAnswer will always be the same as in the latestRoundData
+     * @return int256 Returns the last finalized price of the chainlink oracle
+     */
+    function latestAnswer() external view returns (int256){
+        (,int256 latestPrice,,,) = latestRoundData();
+        return latestPrice;
     }
 
     /**
@@ -72,9 +81,9 @@ contract WbtcPriceFeed {
         //0 index is wbtc usdt price
         //Reduce to 8 decimals to be in line with chainlink oracles
         int crvWbtcToUsdt = int(tricrypto.price_oracle(0));
-        (,int usdtToEth,,,) = usdtToEth.latestRoundData();
-        (,int ethToUsd,,,) = ethToUsd.latestRoundData();
-        int usdtToUsd = usdtToEth * ethToUsd / 10**18;
+        (,int usdtEth,,,) = usdtToEth.latestRoundData();
+        (,int ethUsd,,,) = ethToUsd.latestRoundData();
+        int usdtToUsd = usdtEth * ethUsd / 10**18;
         return crvWbtcToUsdt * usdtToUsd / 10**18;
         
     }

--- a/src/test/feedForkTests/WbtcFeedFork.t.sol
+++ b/src/test/feedForkTests/WbtcFeedFork.t.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED 
+pragma solidity ^0.8.13; 
+ 
+import "forge-std/Test.sol"; 
+import "../../feeds/WbtcPriceFeed.sol"; 
+
+contract WbtcFeedFork is Test {
+
+    WbtcPriceFeed feed;
+
+    function setUp() public {
+        string memory url = vm.rpcUrl("mainnet");
+        vm.createSelectFork(url);
+        feed = new WbtcPriceFeed();
+    }
+
+    function testNominalCaseWithinBounds() public {
+        (uint80 clRoundId1, int256 btcToUsdPrice, uint clStartedAt1, uint clUpdatedAt1,  uint80 clAnsweredInRound1) = feed.btcToUsd().latestRoundData();
+        (uint80 clRoundId2, int256 wbtcToBtcPrice, uint clStartedAt2, uint clUpdatedAt2,  uint80 clAnsweredInRound2) = feed.wbtcToBtc().latestRoundData();
+        (uint80 roundId, int256 wbtcUsdPrice, uint startedAt, uint updatedAt, uint80 answeredInRound) = feed.latestRoundData();
+
+        if(clUpdatedAt1 < clUpdatedAt2){
+            assertEq(clRoundId1, roundId);
+            assertEq(clStartedAt1, startedAt);
+            assertEq(clUpdatedAt1, updatedAt);
+            assertEq(clAnsweredInRound1, answeredInRound);
+        } else {
+            assertEq(clRoundId2, roundId);
+            assertEq(clStartedAt2, startedAt);
+            assertEq(clUpdatedAt2, updatedAt);
+            assertEq(clAnsweredInRound2, answeredInRound);
+        }
+        
+        assertGt(wbtcUsdPrice, 10**8); 
+        assertEq(btcToUsdPrice * 10**8 / wbtcToBtcPrice, wbtcUsdPrice);
+        if(wbtcToBtcPrice > 10**8) assertGt(btcToUsdPrice, wbtcUsdPrice);
+        if(wbtcToBtcPrice < 10**8) assertGt(wbtcUsdPrice, btcToUsdPrice);
+    }
+}
+

--- a/src/test/feedForkTests/WbtcFeedFork.t.sol
+++ b/src/test/feedForkTests/WbtcFeedFork.t.sol
@@ -62,7 +62,7 @@ contract WbtcFeedFork is Test {
        
         assertLt(wbtcUsdPrice, 10**18, "Wbtc usd price greater than 10**18"); 
         assertGt(wbtcUsdPrice, 10**8, "Wbtc usd price less than 10**8"); 
-        assertEq(feed.wbtcToUsdFallback(), wbtcUsdPrice, "Did not return fallback price");
+        assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
     }
 
     function testWillReturnFallbackWhenOutOfMinBounds() public {
@@ -90,7 +90,7 @@ contract WbtcFeedFork is Test {
        
         assertLt(wbtcUsdPrice, 10**18, "Wbtc usd price greater than 10**18"); 
         assertGt(wbtcUsdPrice, 10**8, "Wbtc usd price less than 10**8"); 
-        assertEq(feed.wbtcToUsdFallback(), wbtcUsdPrice, "Did not return fallback price");
+        assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
     }
 }
 

--- a/src/test/feedForkTests/WbtcFeedFork.t.sol
+++ b/src/test/feedForkTests/WbtcFeedFork.t.sol
@@ -14,7 +14,7 @@ contract WbtcFeedFork is Test {
         feed = new WbtcPriceFeed();
     }
 
-    function testNominalCaseWithinBounds() public {
+    function test_latestRoundData_NominalCaseWithinBounds() public {
         (uint80 clRoundId1, int256 btcToUsdPrice, uint clStartedAt1, uint clUpdatedAt1,  uint80 clAnsweredInRound1) = feed.btcToUsd().latestRoundData();
         (uint80 clRoundId2, int256 wbtcToBtcPrice, uint clStartedAt2, uint clUpdatedAt2,  uint80 clAnsweredInRound2) = feed.wbtcToBtc().latestRoundData();
         (uint80 roundId, int256 wbtcUsdPrice, uint startedAt, uint updatedAt, uint80 answeredInRound) = feed.latestRoundData();
@@ -37,7 +37,7 @@ contract WbtcFeedFork is Test {
         if(wbtcToBtcPrice < 10**8) assertGt(wbtcUsdPrice, btcToUsdPrice);
     }
 
-    function testWillReturnFallbackWhenOutOfMaxBounds() public {
+    function test_latestRoundData_WillReturnFallbackWhenOutOfMaxBounds() public {
         (uint80 clRoundId1, int256 btcToUsdPrice, uint clStartedAt1, uint clUpdatedAt1,  uint80 clAnsweredInRound1) = feed.btcToUsd().latestRoundData();
         (uint80 clRoundId2, int256 wbtcToBtcPrice, uint clStartedAt2, uint clUpdatedAt2,  uint80 clAnsweredInRound2) = feed.wbtcToBtc().latestRoundData();
         vm.mockCall(
@@ -64,7 +64,7 @@ contract WbtcFeedFork is Test {
         assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
     }
 
-    function testWillReturnFallbackWhenOutOfMinBounds() public {
+    function test_latestRoundData_WillReturnFallbackWhenOutOfMinBounds() public {
         (uint80 clRoundId1, int256 btcToUsdPrice, uint clStartedAt1, uint clUpdatedAt1,  uint80 clAnsweredInRound1) = feed.btcToUsd().latestRoundData();
         (uint80 clRoundId2, int256 wbtcToBtcPrice, uint clStartedAt2, uint clUpdatedAt2,  uint80 clAnsweredInRound2) = feed.wbtcToBtc().latestRoundData();
         vm.mockCall(
@@ -90,6 +90,13 @@ contract WbtcFeedFork is Test {
         assertLt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 110 / 100, "Fallback price more than 10% higher than oracle"); 
         assertGt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 90 / 100, "Wbtc more than 10% lower than oracle"); 
         assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
+    }
+
+    function test_latestAnswer_ReturnSameAsLatestRoundData() public {
+        (,int btcLRD,,,) = feed.wbtcToBtc().latestRoundData();
+        int btcLA = feed.wbtcToBtc().latestAnswer();
+
+        assertEq(btcLRD, btcLA);
     }
 }
 

--- a/src/test/feedForkTests/WbtcFeedFork.t.sol
+++ b/src/test/feedForkTests/WbtcFeedFork.t.sol
@@ -59,9 +59,8 @@ contract WbtcFeedFork is Test {
             assertEq(clUpdatedAt2, updatedAt);
             assertEq(clAnsweredInRound2, answeredInRound);
         }
-       
-        assertLt(wbtcUsdPrice, 10**18, "Wbtc usd price greater than 10**18"); 
-        assertGt(wbtcUsdPrice, 10**8, "Wbtc usd price less than 10**8"); 
+         assertLt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 110 / 100, "Fallback price more than 10% higher than oracle"); 
+        assertGt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 90 / 100, "Wbtc more than 10% lower than oracle"); 
         assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
     }
 
@@ -88,8 +87,8 @@ contract WbtcFeedFork is Test {
             assertEq(clAnsweredInRound2, answeredInRound);
         }
        
-        assertLt(wbtcUsdPrice, 10**18, "Wbtc usd price greater than 10**18"); 
-        assertGt(wbtcUsdPrice, 10**8, "Wbtc usd price less than 10**8"); 
+        assertLt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 110 / 100, "Fallback price more than 10% higher than oracle"); 
+        assertGt(wbtcUsdPrice, feed.btcToUsd().latestAnswer() * 90 / 100, "Wbtc more than 10% lower than oracle"); 
         assertEq(feed.wbtcToUsdFallbackOracle(), wbtcUsdPrice, "Did not return fallback price");
     }
 }

--- a/src/test/marketForkTests/InvMarketForkTest.t.sol
+++ b/src/test/marketForkTests/InvMarketForkTest.t.sol
@@ -36,10 +36,12 @@ contract InvMarketForkTest is MarketForkTest {
         vm.startPrank(gov);
         dbr.addMinter(address(distributor));
         market.pauseBorrows(true);
+        distributor.setRewardRateConstraints(126839167935058000,317097919837646000);
+        distributor.setRewardRateConstraints(0,317097919837646000);
         vm.stopPrank();
-        vm.startPrank(chair, chair);
-        distributor.setRewardRate(1 ether);
-        vm.stopPrank();
+        //vm.startPrank(chair, chair);
+        //distributor.setRewardRate(1 ether);
+        //vm.stopPrank();
 
         borrowContract = new BorrowContract(address(market), payable(address(collateral)));
     }


### PR DESCRIPTION
* Add custom price feed using chainlink oracle for WBTC/BTC price and  chainlink oracle for BTC/USD price to compute WBTC/USD price.

The pricefeed uses the tricrypto CRV pool as a fallback oracle if the price <= max or min price of the chainlink oracle. This is to keep positions liquidateable, even in the case where WBTC may lose backing.