### PR TITLE
docs: fix typo sandwhiching -> sandwiching

### DIFF
--- a/src/interfaces/IConvexBooster.sol
+++ b/src/interfaces/IConvexBooster.sol
@@ -1,9 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8.13;
 
+/// @title IConvexBooster
+/// @notice Interface for the Convex Finance Booster contract
+/// @dev Used to interact with Convex pools for depositing, withdrawing, and claiming rewards
 interface IConvexBooster {
+    /// @notice Withdraws LP tokens from a Convex pool
+    /// @param pid The pool ID to withdraw from
+    /// @param _amount The amount of LP tokens to withdraw
     function withdraw(uint256 pid, uint256 _amount) external;
 
+    /// @notice Deposits LP tokens into a Convex pool
+    /// @param pid The pool ID to deposit into
+    /// @param amount The amount of LP tokens to deposit
+    /// @param stake Whether to stake the deposit in the rewards contract
     function deposit(uint256 pid, uint256 amount, bool stake) external;
 
+    /// @notice Claims pending CRV and CVX rewards for a pool and transfers them to the reward contract
+    /// @param pid The pool ID to claim rewards for
     function earmarkRewards(uint256 pid) external;
 }

--- a/src/util/OffchainAbstractHelper.sol
+++ b/src/util/OffchainAbstractHelper.sol
@@ -52,7 +52,7 @@ abstract contract OffchainAbstractHelper {
     @param market Market the caller wishes to borrow from
     @param dolaAmount Amount the caller wants to end up with at their disposal
     @param dolaForDbr The max amount of debt the caller is willing to end up with
-     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     This is a sensitive parameter and should be reasonably low to prevent sandwiching.
      A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
     @param minDbr The minDbr the caller wish to borrow for
     @param deadline Deadline of the signature
@@ -88,7 +88,7 @@ abstract contract OffchainAbstractHelper {
     @param market Market the caller wish to deposit to and borrow from
     @param dolaAmount Amount the caller wants to end up with at their disposal
     @param dolaForDbr The max amount of debt the caller is willing to take on to buy dbr
-     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     This is a sensitive parameter and should be reasonably low to prevent sandwiching.
      A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
     @param minDbr The minDbr the caller wish to borrow for
     @param deadline Deadline of the signature
@@ -126,7 +126,7 @@ abstract contract OffchainAbstractHelper {
     @param market Market the caller wish to deposit to and borrow from
     @param dolaAmount Amount the caller wants to end up with at their disposal
     @param dolaForDbr The max amount of debt the caller is willing to end up with
-     This is a sensitive parameter and should be reasonably low to prevent sandwhiching.
+     This is a sensitive parameter and should be reasonably low to prevent sandwiching.
      A good estimate can be calculated given the approximateDolaAndDbrNeeded function, though should be set slightly higher.
     @param minDbr The minDbr the caller wish to borrow for
     @param deadline Deadline of the signature
@@ -163,7 +163,7 @@ abstract contract OffchainAbstractHelper {
     @param market The market the user wishes to repay debt in
     @param dolaAmount The maximum amount of dola debt the user is willing to repay
     @param minDolaFromDbr The minimum amount of DOLA the caller expects to get in return for selling their DBR.
-     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwiching.
     @param dbrAmountToSell The amount of DBR the caller wishes to sell
     */
     function sellDbrAndRepayOnBehalf(IMarket market, uint dolaAmount, uint minDolaFromDbr, uint dbrAmountToSell) public {
@@ -202,7 +202,7 @@ abstract contract OffchainAbstractHelper {
     @param market Market the user wishes to repay debt in
     @param dolaAmount Maximum amount of dola debt the user is willing to repay
     @param minDolaFromDbr Minimum amount of DOLA the caller expects to get in return for selling their DBR
-     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwiching.
     @param dbrAmountToSell Amount of DBR the caller wishes to sell
     @param collateralAmount Amount of collateral to withdraw
     @param deadline Deadline of the signature
@@ -238,7 +238,7 @@ abstract contract OffchainAbstractHelper {
     @param market Market the user wishes to repay debt in
     @param dolaAmount Maximum amount of dola debt the user is willing to repay
     @param minDolaFromDbr Minimum amount of DOLA the caller expects to get in return for selling their DBR
-     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwhiching.
+     This is a sensitive parameter and should be provided with reasonably low slippage to prevent sandwiching.
     @param dbrAmountToSell Amount of DBR the caller wishes to sell
     @param collateralAmount Amount of collateral to withdraw
     @param deadline Deadline of the signature


### PR DESCRIPTION
## Description
Documentation improvements for the FiRM codebase.

## Changes

### 1. Typo Fix
- Fixed "sandwhiching" → "sandwiching" (6 occurrences in `OffchainAbstractHelper.sol`)

### 2. NatSpec Documentation
- Added complete NatSpec documentation to `IConvexBooster` interface:
  - `@title`, `@notice`, `@dev` for the interface
  - `@notice` and `@param` for each function (`withdraw`, `deposit`, `earmarkRewards`)
  - Added missing SPDX license identifier

## Files Changed
- `src/util/OffchainAbstractHelper.sol`
- `src/interfaces/IConvexBooster.sol`