### PR TITLE
Fix/add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Adekunle Bamz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ FiRM is built using [Foundry](https://book.getfoundry.sh/getting-started/install
 ## Test
 To run tests, you must first add an `RPC_MAINNET` rpc endpoint to your local `.env` file.
 
-To generate a coverage summary run `forge coverage`, and `forge coverage --reprot lcov` for a full coverage report. To generate a human readable document from the lcov.info file, use the following command:
+To generate a coverage summary run `forge coverage`, and `forge coverage --report lcov` for a full coverage report. To generate a human readable document from the lcov.info file, use the following command:
 `genhtml -o report --branch-coverage`
 


### PR DESCRIPTION
This PR adds a MIT LICENSE file to the repository. The LICENSE file grants permission to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the software, subject to the conditions outlined in the MIT License.

Changes:
- Added LICENSE file with MIT License content